### PR TITLE
Prevent increment order bug on some compilers.

### DIFF
--- a/json-builder.c
+++ b/json-builder.c
@@ -593,7 +593,8 @@ size_t json_measure_ex (json_value * value, json_serialize_opts opts)
                MEASURE_NEWLINE();
             }
 
-            value = value->u.array.values [((json_builder_value *) value)->length_iterated ++];
+            ((json_builder_value *) value)->length_iterated++;
+            value = value->u.array.values [((json_builder_value *) value)->length_iterated - 1];
             continue;
 
          case json_object:


### PR DESCRIPTION
Visual studio interprets post decrements very literally and increments
the child's length_iterated element instead of the array's element.

Type: Bug Fix
