### PR TITLE
A few small fixes for strict compiler settings.

### DIFF
--- a/json-builder.c
+++ b/json-builder.c
@@ -39,7 +39,7 @@
     #define snprintf _snprintf
 #endif
 
-const static json_serialize_opts default_opts =
+static const json_serialize_opts default_opts =
 {
    json_serialize_mode_single_line,
    0,
@@ -99,7 +99,7 @@ const int f_spaces_after_commas    = (1 << 1);
 const int f_spaces_after_colons    = (1 << 2);
 const int f_tabs                   = (1 << 3);
 
-int get_serialize_flags (json_serialize_opts opts)
+static int get_serialize_flags (json_serialize_opts opts)
 {
    int flags = 0;
 
@@ -357,7 +357,7 @@ json_value * json_boolean_new (int b)
    return value;
 }
 
-json_value * json_null_new ()
+json_value * json_null_new (void)
 {
    json_value * value = (json_value *) calloc (1, sizeof (json_builder_value));
    

--- a/json-builder.c
+++ b/json-builder.c
@@ -885,7 +885,7 @@ void json_serialize_ex (json_char * buf, json_value * value, json_serialize_opts
             {
                *dot = '.';
             }
-            else if (!strchr (ptr, '.'))
+            else if (!strchr (ptr, '.') && !strchr (ptr, 'e'))
             {
                *buf ++ = '.';
                *buf ++ = '0';

--- a/json-builder.c
+++ b/json-builder.c
@@ -33,11 +33,14 @@
 #include <string.h>
 #include <assert.h>
 #include <stdio.h>
-#include <math.h>
 
 #ifdef _MSC_VER
     #define snprintf _snprintf
 #endif
+
+static double floor(double d) {
+       return d - ((int)d % 1);
+}
 
 static const json_serialize_opts default_opts =
 {

--- a/json-builder.h
+++ b/json-builder.h
@@ -107,7 +107,7 @@ json_value * json_string_new_nocopy (unsigned int length, json_char *);
 json_value * json_integer_new (json_int_t);
 json_value * json_double_new (double);
 json_value * json_boolean_new (int);
-json_value * json_null_new ();
+json_value * json_null_new (void);
 
 
 /*** Serializing

--- a/test/main.cc
+++ b/test/main.cc
@@ -127,11 +127,17 @@ void test_buf (char * buffer, size_t size, int * num_failed)
    char * buf = (char *) malloc (measured);
    json_serialize (buf, value);
 
-   printf ("serialized len: %d\n", (int) strlen (buf) + 1);
+   size_t serialized = (int) strlen (buf) + 1;
+   printf ("serialized len: %d\n", serialized);
 
    printf ("serialized:\n%s\n", buf);
 
-   if (! (value2 = json_parse_ex (&settings, buf, strlen(buf), error)))
+   if (serialized > measured)
+   {
+      printf ("Serialized more than measured\n");
+      ++ *num_failed;
+   }
+   else if (! (value2 = json_parse_ex (&settings, buf, strlen(buf), error)))
    {
       printf ("Failed to re-parse: %s\n", error);
       ++ *num_failed;


### PR DESCRIPTION
Especially the fix in the header is important because it forces one to tone
down compile strictness if you want to include this header. Compiled with
gcc and added at least -Wextra -Werror -Wstrict-prototypes
-Wmissing-prototypes.