### PR TITLE
Include stdlib.h in json-builder.c

### DIFF
--- a/json-builder.c
+++ b/json-builder.c
@@ -32,6 +32,7 @@
 
 #include <string.h>
 #include <assert.h>
+#include <stdlib.h>
 #include <stdio.h>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
In `json-builder.c` there are calls to `malloc` and `free`, but `stdlib.h` is not included.
It used to be included via `json-builder.h` from `json.h`
But `json.h` doesn't include it anymore
https://github.com/json-parser/json-parser/commit/b5ce13ee6437f1ccc49eb360e0ab465ba2d89cc6